### PR TITLE
Add ignore entry to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,5 +11,12 @@
   },
   "main": [
     "src/sb-date-select.js"
+  ],
+  "ignore": [
+    "**/.*",
+    "*.md",
+    "*.html",
+    "test",
+    "package.json"
   ]
 }


### PR DESCRIPTION
https://github.com/bower/spec/blob/master/json.md#ignore

When installing, bower whines about missing `ignore`:
```
bower angular-sb-date-select#*     invalid-meta angular-sb-date-select is missing "ignore" entry in bower.json
```