### PR TITLE
#7 Add possibility to pass custom template

### DIFF
--- a/src/sb-date-select.js
+++ b/src/sb-date-select.js
@@ -2,7 +2,7 @@
 
 angular.module('sbDateSelect', [])
 
-  .directive('sbDateSelect', [function () {
+  .run(["$templateCache", function ($templateCache) {
 
     var template = [
       '<div class="sb-date-select">',
@@ -18,10 +18,18 @@ angular.module('sbDateSelect', [])
       '</div>'
     ];
 
+    $templateCache.put("sb-date-select.html", template.join(''));
+
+  }])
+
+  .directive('sbDateSelect', [function () {
+
     return {
       restrict: 'A',
       replace: true,
-      template: template.join(''),
+      templateUrl: function ($element, $attrs) {
+        return $attrs.templateUrl || 'sb-date-select.html'
+      },
       require: 'ngModel',
       scope: {
         selectClass: '@sbSelectClass'
@@ -87,7 +95,7 @@ angular.module('sbDateSelect', [])
 
           if (scope.val.year && scope.val.month && max.isSame([scope.val.year, scope.val.month-1], 'month')) {
             maxDate = max.date();
-          } else if (scope.val.year && scope.val.month) { 
+          } else if (scope.val.year && scope.val.month) {
             maxDate = moment([scope.val.year, scope.val.month-1]).daysInMonth();
           } else {
             maxDate = 31;
@@ -117,4 +125,3 @@ angular.module('sbDateSelect', [])
       }
     };
   }]);
-

--- a/src/sb-date-select.js
+++ b/src/sb-date-select.js
@@ -2,14 +2,14 @@
 
 angular.module('sbDateSelect', [])
 
-  .run(["$templateCache", function ($templateCache) {
+  .run(['$templateCache', function ($templateCache) {
 
     var template = [
       '<div class="sb-date-select">',
-        '<select class="sb-date-select-day sb-date-select-select" ng-class="selectClass" ng-model="val.date", ng-options="d for d in dates track by d">',
+        '<select class="sb-date-select-day sb-date-select-select" ng-class="selectClass" ng-model="val.date" ng-options="d for d in dates track by d">',
           '<option value disabled selected>Day</option>',
         '</select>',
-        '<select class="sb-date-select-month sb-date-select-select" ng-class="selectClass" ng-model="val.month", ng-options="m.value as m.name for m in months">',
+        '<select class="sb-date-select-month sb-date-select-select" ng-class="selectClass" ng-model="val.month" ng-options="m.value as m.name for m in months">',
           '<option value disabled>Month</option>',
         '</select>',
         '<select class="sb-date-select-year sb-date-select-select" ng-class="selectClass" ng-model="val.year" ng-options="y for y in years">',
@@ -18,7 +18,7 @@ angular.module('sbDateSelect', [])
       '</div>'
     ];
 
-    $templateCache.put("sb-date-select.html", template.join(''));
+    $templateCache.put('sb-date-select.html', template.join(''));
 
   }])
 
@@ -28,7 +28,7 @@ angular.module('sbDateSelect', [])
       restrict: 'A',
       replace: true,
       templateUrl: function ($element, $attrs) {
-        return $attrs.templateUrl || 'sb-date-select.html'
+        return $attrs.templateUrl || 'sb-date-select.html';
       },
       require: 'ngModel',
       scope: {


### PR DESCRIPTION
Closes #7 

Defaults to template coming with this directive, but allows overwriting it:

``` html
<div sb-date-select template-url="custom-date-selector.html" ng-model="myModel"></div>

<script type="text/ng-template" id="custom-date-selector.html">
  <h4>Custom date selector template example</h4>
  <div class="sb-date-select">
    <select class="sb-date-select-day sb-date-select-select" ng-class="selectClass" ng-model="val.date" ng-options="d for d in dates track by d">
      <option value disabled selected>Day</option>
    </select>
    <select class="sb-date-select-month sb-date-select-select" ng-class="selectClass" ng-model="val.month" ng-options="m.value as m.name for m in months">
      <option value disabled>Month</option>
    </select>
    <select class="sb-date-select-year sb-date-select-select" ng-class="selectClass" ng-model="val.year" ng-options="y for y in years">
      <option value disabled selected>Year</option>
    </select>
  </div>
</script>
```

I didn't add documentation to Readme yet, but I can add it later if you think this is a good addition and merge #6 first.

Cheers! :-)
